### PR TITLE
Give shutdown message box more descriptive buttons

### DIFF
--- a/src-qt5/PCDM/src/pcdm-gui.cpp
+++ b/src-qt5/PCDM/src/pcdm-gui.cpp
@@ -452,8 +452,9 @@ void PCDMgui::slotShutdownComputer(){
   verify.setWindowTitle(tr("System Shutdown"));
   verify.setText(tr("You are about to shut down the system."));
   verify.setInformativeText(tr("Are you sure?"));
-  verify.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-  verify.setDefaultButton(QMessageBox::No);
+  verify.addButton(tr("Shutdown"), QMessageBox::AcceptRole);
+  verify.addButton(QMessageBox::Cancel);
+  verify.setDefaultButton(QMessageBox::Cancel);
   int ret = verify.exec();
 
   if(ret == QMessageBox::Yes){


### PR DESCRIPTION
Instead of just having yes/no buttons on the messagebox that shows up
for shutdown, give the "Yes" button a better text ("Shutdown"), and make
"No", "Cancel".  That way it's easier to see at a glance which button to
press.

I'm sorry, but I just don't like message boxes that have a "Yes/No" set up. You can always put an action verb in there and the question still works.