### PR TITLE
Change APP_STYLESHEET_END to APP_STYLESHEET_STOP to match the theme files.

### DIFF
--- a/src-qt5/PCDM/src/themeStruct.cpp
+++ b/src-qt5/PCDM/src/themeStruct.cpp
@@ -37,7 +37,7 @@ void ThemeStruct::loadThemeFile(QString filePath){
     else if(line.startsWith("APP_STYLESHEET_START")){ 
       //save all the following lines as the stylesheet
       QStringList styleLines;
-      while( !line.startsWith("APP_STYLESHEET_END") && !in.atEnd() ){
+      while( !line.startsWith("APP_STYLESHEET_STOP") && !in.atEnd() ){
         line = in.readLine().simplified();
 	styleLines << line;
       }


### PR DESCRIPTION
The code has been looking for APP_STYLESHEET_END, whereas the themes
have been using APP_STYLESHEET_STOP. It works the way that it's been,
because the code also checks for the end of the file, and
APP_STYLESHEET_STOP is at the end of the file, but they really should
match. I'm not sure that it really matters whether it's END or STOP, but
I went with STOP, because that meant changing one line of code instead
of changing all of the themes.