### PR TITLE
Fixed issue when PCDM UI failed to come back after Driver Reset button was actioned

### DIFF
--- a/src-qt5/PCDM/src/main.cpp
+++ b/src-qt5/PCDM/src/main.cpp
@@ -299,8 +299,14 @@ int main(int argc, char *argv[])
     qDebug() << "-- Session ID:" << sid;*/
     int retCode = runSingleSession(argc,argv);
     qDebug() << "-- PCDM Session Ended --";
-    //check for special exit code
 
+    // Need to clean up pid file otherwise daemon restart command fails
+    // saying process is already running
+    if(QFile::exists("/var/run/PCDMd-" + VT + ".pid")) 
+    {
+       QFile::remove("/var/run/PCDMd-" + VT+ ".pid");
+    } 
+    //check for special exit code
     if(retCode == -1){ neverquit=true; } //make sure we go around again at least once
     else if(retCode != 0){ neverquit=false; }
     //Now kill the shild process (whole session)

--- a/src-qt5/PCDM/src/main.cpp
+++ b/src-qt5/PCDM/src/main.cpp
@@ -300,12 +300,7 @@ int main(int argc, char *argv[])
     int retCode = runSingleSession(argc,argv);
     qDebug() << "-- PCDM Session Ended --";
 
-    // Need to clean up pid file otherwise daemon restart command fails
-    // saying process is already running
-    if(QFile::exists("/var/run/PCDMd-" + VT + ".pid")) 
-    {
-       QFile::remove("/var/run/PCDMd-" + VT+ ".pid");
-    } 
+
     //check for special exit code
     if(retCode == -1){ neverquit=true; } //make sure we go around again at least once
     else if(retCode != 0){ neverquit=false; }
@@ -323,7 +318,12 @@ int main(int argc, char *argv[])
   qDebug() << "-- PCDM Session Ended --";
   if(QFile::exists("/var/run/nologin") || QFile::exists(TMPSTOPFILE.arg(VT)) ){ neverquit = false; }
  }
-
+ // Need to clean up pid file otherwise daemon restart command fails
+ // saying process is already running
+ if(QFile::exists("/var/run/PCDMd-" + VT + ".pid")) 
+ {
+    QFile::remove("/var/run/PCDMd-" + VT+ ".pid");
+ } 
  if(logfile != nullptr)
  {
     delete logfile;	 


### PR DESCRIPTION
The issue was that the following PID file from previous run was still there and **service pcdm setupx**  failed saying the process is already running 

> /var/run/PCDMd-vt9.pid


Here is error of the failure from the system log:

> Oct 20 21:28:49  /usr/local/etc/init.d/pcdm.vt9[62668]: start-stop-daemon: /usr/local/sbin/PCDMd is already running
> Oct 20 21:28:49  /usr/local/etc/init.d/pcdm.vt9[48547]: ERROR: pcdm.vt9 failed to start
> Oct 20 21:28:50  kernel: uhub_reattach_port: giving up port reset - device vanished
> Oct 20 21:28:50  /usr/local/etc/init.d/pcdm.vt9[66867]: start-stop-daemon: /usr/local/sbin/PCDMd is already running
> Oct 20 21:28:50  /usr/local/etc/init.d/pcdm.vt9[63480]: ERROR: pcdm.vt9 failed to start

