### PR TITLE
rc script: Add `moused` to REQUIRE

### DIFF
--- a/src-qt5/rc.d/pcdm
+++ b/src-qt5/rc.d/pcdm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # PROVIDE: pcdm
-# REQUIRE: LOGIN cleanvar dbus
+# REQUIRE: LOGIN cleanvar dbus moused
 # KEYWORD: shutdown
 # Add the following to /etc/rc.conf to start PCDM at boot time:
 #


### PR DESCRIPTION
For people who use moused in their X session, if PCDM starts before moused, moused will fail to start.
This patch tells PCDM to start after moused. Note that the REQUIRE keyword does not in fact **require** moused: it just tells rcorder to put moused before PCDM, _if_ it is enabled (see the BUGS section in `rcorder(8)`).

Context: Starting moused for an X session may sound like an exotic use case, but unless I am mistaken, it is currently the usual way to get Synaptics touchpad features. Hopefully that will change in the future (I think we might be getting evdev in CURRENT?), but for now this is a valid use case. And in any case, pcdm shouldn't break the user's setup if for any reason they decide to have moused enabled.